### PR TITLE
Update pixi manifest

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -1,4 +1,4 @@
-[project]
+[workspace]
 name = "ship-routing"
 version = "2024.04.10.1"
 description = "Ship Route Optimisation"
@@ -32,6 +32,7 @@ zarr = "*"
 tests = "pytest -q"
 lint = "black --check src tests"
 format = "black src tests"
+jupyterlab = "jupyter lab"
 
 [pypi-dependencies]
 "ship_routing" = { path = ".", editable = true }


### PR DESCRIPTION
## Summary

- switch the manifest to the new [workspace] table so pixi can manage multi-package metadata correctly
- add a convenient jupyterlab task to mirror local workflows

## Testing
- not run (metadata-only change)
